### PR TITLE
removed useless "x" button for Yes/No dialogues

### DIFF
--- a/mayan/apps/appearance/templates/appearance/generic_confirm.html
+++ b/mayan/apps/appearance/templates/appearance/generic_confirm.html
@@ -9,7 +9,6 @@
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">
-                <button type="button" class="close" data-dismiss="modal" aria-hidden="true">×</button>
                 <h4 class="modal-title">
                     <h3>{% trans 'Are you sure?' %}</h3>
                 </h4>


### PR DESCRIPTION
Fixes #1, more of a test pr

original hw1 message:

Quick fix for issue [#63](https://github.com/CMU-313/Mayan-EDMS/issues/63). There was a useless, invisible close-button for Yes/No dialogues that could be confusing for screen readers and users alike.

I simply removed the button, and the accessibility score improved by a couple points.